### PR TITLE
add a_jazz/akc084 via keymap

### DIFF
--- a/keyboards/a_jazz/akc084/keymaps/via/keymap.c
+++ b/keyboards/a_jazz/akc084/keymaps/via/keymap.c
@@ -1,0 +1,43 @@
+/* Copyright 2024 Feng
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [0] =  { ENCODER_CCW_CW(KC_VOLD, KC_VOLU)  },
+    [1] =  { ENCODER_CCW_CW(_______, _______)  }
+};
+#endif
+
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_PSCR, KC_SCRL, KC_PAUS, KC_MUTE,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_RALT, MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT
+    ),
+    [1] = LAYOUT(
+        _______,   KC_MSEL,   KC_VOLD,    KC_VOLU,   KC_MUTE,   KC_MSTP,    KC_MPRV,   KC_MPLY,   KC_MNXT,   KC_MAIL,   KC_WHOM,  KC_MYCM, KC_CALC,    _______,   _______,  _______,   _______,
+        _______,   _______,   _______,    _______,   _______,   _______,    _______,   _______,   _______,   _______,   _______,   _______,  _______,  _______,  KC_INS,
+        _______,   _______,   _______,    _______,   _______,   _______,    _______,   _______,   _______,   _______,   _______,   _______,  _______,  _______,  KC_END,
+        _______,   _______,   _______,    _______,   _______,   _______,    _______,   _______,   _______,   _______,   _______,   _______,  _______,  KC_PSCR,
+        _______,   _______,   _______,    _______,   _______,   _______,    _______,   _______,   _______,   _______,   _______,   _______,  _______,  KC_SCRL,
+        _______,   _______,   _______,                          _______,               _______,   _______,   _______,   _______,   _______,  _______
+    )
+};

--- a/keyboards/a_jazz/akc084/keymaps/via/rules.mk
+++ b/keyboards/a_jazz/akc084/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
add a_jazz/akc084 via keymap
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
add a_jazz/akc084 via keymap
<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/24224
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] VIA keymap uses custom menus **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [x] The Vendor ID is not `0xFEED`
