### PR TITLE
Add VIA Support for PH-AC

### DIFF
--- a/keyboards/phdesign/phac/keymaps/via/keymap.c
+++ b/keyboards/phdesign/phac/keymaps/via/keymap.c
@@ -1,0 +1,22 @@
+// Copyright 2023 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+    _BL,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_BL] = LAYOUT(
+                    KC_B,
+        KC_S,   KC_D,   KC_K,   KC_L,
+            KC_V,           KC_N
+    )
+};
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [_BL] = { ENCODER_CCW_CW(MS_UP, MS_DOWN),  ENCODER_CCW_CW(MS_LEFT, MS_RGHT)  },
+};
+#endif

--- a/keyboards/phdesign/phac/keymaps/via/rules.mk
+++ b/keyboards/phdesign/phac/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+ENCODER_MAP_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Add VIA support for ph.design PH-AC rhythm game controller

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

https://github.com/qmk/qmk_firmware/pull/24368

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
