### PR TITLE
Add ctrl_m

### DIFF
--- a/keyboards/ibm/model_m/ctrl_m/keymaps/via/keymap.c
+++ b/keyboards/ibm/model_m/ctrl_m/keymaps/via/keymap.c
@@ -1,0 +1,27 @@
+/* Copyright 2020 Michael Schwingen
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT_all( /* Base layer - standard layout without any special functions */
+    KC_ESC ,          KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 , KC_PSCR, KC_SCRL, KC_PAUS,
+    KC_GRV , KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , KC_MINS, KC_EQL , KC_BSPC, KC_INS , KC_HOME, KC_PGUP, KC_NUM,  KC_PSLS, KC_PAST, KC_PMNS,
+    KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL , KC_END , KC_PGDN, KC_P7,   KC_P8  , KC_P9  , KC_PPLS,
+    KC_CAPS, KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT ,                            KC_P4,   KC_P5  , KC_P6  ,
+    KC_LSFT, KC_NUBS, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH,          KC_RSFT,          KC_UP  ,          KC_P1,   KC_P2  , KC_P3  , KC_PENT,
+    KC_LCTL,          KC_LALT,                            KC_SPC ,                                     KC_RALT,          KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT, KC_P0,            KC_PDOT
+  )
+};

--- a/keyboards/ibm/model_m/ctrl_m/keymaps/via/rules.mk
+++ b/keyboards/ibm/model_m/ctrl_m/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding keyboard definition to the qmk_userspace_via for the ctrl-M replacement controller for IBM Model M keyboards.

Detailed description of the ctrl-M controller:
https://brain4free.org/wiki/doku.php/elektronik:ctrl_m

## QMK Pull Request

Link to merged QMK Pull Request:

https://github.com/qmk/qmk_firmware/pull/24375

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
