### PR TITLE
Adding VIA keymap to keyboard shuguet/shu89

### DIFF
--- a/keyboards/shuguet/shu89/keymaps/via/keymap.json
+++ b/keyboards/shuguet/shu89/keymaps/via/keymap.json
@@ -1,0 +1,28 @@
+{
+    "keyboard": "shuguet/shu89",
+    "keymap": "via",
+    "config": {
+        "features": {
+            "via": true
+        }
+    },
+    "layout": "LAYOUT",
+    "layers": [
+        [
+            "KC_ESC" , "KC_F1"  , "KC_F2"  , "KC_F3"  , "KC_F4"              , "KC_F5"  ,               "KC_F6"              , "KC_F7"  , "KC_F8"  , "KC_F9"  , "KC_F10" , "KC_F11" , "KC_F12" , "KC_PSCR", "KC_SCRL", "KC_PAUS",
+            "KC_GRV" , "KC_1"   , "KC_2"   , "KC_3"   , "KC_4"               , "KC_5"   , "KC_6"   ,    "KC_7"               , "KC_8"   , "KC_9"   , "KC_0"   , "KC_MINS", "KC_EQL" , "KC_BSPC", "KC_INS" , "KC_HOME", "KC_PGUP",
+            "KC_TAB" , "KC_Q"   , "KC_W"   , "KC_E"   , "KC_R"               , "KC_T"   ,               "KC_Y"               , "KC_U"   , "KC_I"   , "KC_O"   , "KC_P"   , "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL" , "KC_END" , "KC_PGDN",
+            "KC_CAPS", "KC_A"   , "KC_S"   , "KC_D"   , "KC_F"               , "KC_G"   ,               "KC_H"               , "KC_J"   , "KC_K"   , "KC_L"   , "KC_SCLN", "KC_QUOT", "KC_ENT" ,
+            "KC_LSFT", "KC_Z"   , "KC_X"   , "KC_C"   , "KC_V"               , "KC_B"   ,               "KC_N"               , "KC_M"   , "KC_COMM", "KC_DOT" , "KC_SLSH", "KC_RSFT", "KC_UP"  ,
+            "KC_LCTL", "MO(1)"  , "KC_LALT", "KC_LGUI", "KC_SPACE"           ,                          "KC_SPACE"           , "KC_RALT", "KC_RGUI", "KC_APP" , "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+        ],
+        [
+            "QK_BOOT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS"            , "KC_TRNS", "KC_TRNS",    "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_TOG"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_VOLU",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MEDIA_PLAY_PAUSE",                          "KC_MEDIA_PLAY_PAUSE", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPRV", "KC_VOLD", "KC_MNXT"
+        ]
+    ]
+}

--- a/keyboards/shuguet/shu89/keymaps/via/keymap.json
+++ b/keyboards/shuguet/shu89/keymaps/via/keymap.json
@@ -22,7 +22,7 @@
             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_TOG"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"            , "KC_TRNS",               "KC_TRNS"            , "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_VOLU",
-            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MEDIA_PLAY_PAUSE",                          "KC_MEDIA_PLAY_PAUSE", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPRV", "KC_VOLD", "KC_MNXT"
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPLY",                          "KC_MPLY", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPRV", "KC_VOLD", "KC_MNXT"
         ]
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Adding a VIA compatible keymap to my new keyboard currently going through PR acceptance on QMK side.

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/24758

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [X] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [X] The Vendor ID is not `0xFEED`
