### PR TITLE
Fix Fuyu WS2812 RGB variable names

### DIFF
--- a/keyboards/zykrah/fuyu/keymaps/via/keymap.c
+++ b/keyboards/zykrah/fuyu/keymaps/via/keymap.c
@@ -102,14 +102,14 @@ bool rgb_matrix_indicators_user(void) {
 #if defined(RGB_MATRIX_ENABLE)
 
 #define INDICATOR_RGB_DIVISOR 4
-extern rgb_led_t rgb_matrix_ws2812_array[WS2812_LED_COUNT];
+extern ws2812_led_t ws2812_leds[WS2812_LED_COUNT];
 bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     for (uint8_t i = led_min; i < led_max; i++) {
         if (g_led_config.flags[i] & LED_FLAG_INDICATOR) {
             RGB temp_rgb = {0};
-            temp_rgb.r   = rgb_matrix_ws2812_array[i].r / INDICATOR_RGB_DIVISOR ;
-            temp_rgb.g   = rgb_matrix_ws2812_array[i].g / INDICATOR_RGB_DIVISOR ;
-            temp_rgb.b   = rgb_matrix_ws2812_array[i].b / INDICATOR_RGB_DIVISOR ;
+            temp_rgb.r   = ws2812_leds[i].r / INDICATOR_RGB_DIVISOR ;
+            temp_rgb.g   = ws2812_leds[i].g / INDICATOR_RGB_DIVISOR ;
+            temp_rgb.b   = ws2812_leds[i].b / INDICATOR_RGB_DIVISOR ;
             rgb_matrix_set_color(i, temp_rgb.r, temp_rgb.g, temp_rgb.b);
         }
 

--- a/keyboards/zykrah/fuyu_hs/keymaps/via/keymap.c
+++ b/keyboards/zykrah/fuyu_hs/keymaps/via/keymap.c
@@ -63,23 +63,23 @@ bool rgb_matrix_indicators_user(void) {
 // Code used to lower the brightness of the indicator LEDs (Snowflake LEDs)
 #if defined(RGB_MATRIX_ENABLE)
 
-#    define INDICATOR_RGB_DIVISOR 4
-extern rgb_led_t rgb_matrix_ws2812_array[WS2812_LED_COUNT];
-bool             rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+#define INDICATOR_RGB_DIVISOR 4
+extern ws2812_led_t ws2812_leds[WS2812_LED_COUNT];
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     for (uint8_t i = led_min; i < led_max; i++) {
         if (g_led_config.flags[i] & LED_FLAG_INDICATOR) {
             RGB temp_rgb = {0};
-            temp_rgb.r   = rgb_matrix_ws2812_array[i].r / INDICATOR_RGB_DIVISOR;
-            temp_rgb.g   = rgb_matrix_ws2812_array[i].g / INDICATOR_RGB_DIVISOR;
-            temp_rgb.b   = rgb_matrix_ws2812_array[i].b / INDICATOR_RGB_DIVISOR;
+            temp_rgb.r   = ws2812_leds[i].r / INDICATOR_RGB_DIVISOR ;
+            temp_rgb.g   = ws2812_leds[i].g / INDICATOR_RGB_DIVISOR ;
+            temp_rgb.b   = ws2812_leds[i].b / INDICATOR_RGB_DIVISOR ;
             rgb_matrix_set_color(i, temp_rgb.r, temp_rgb.g, temp_rgb.b);
         }
 
-#    if !defined(ENABLE_UNDERGLOW)
+        #if !defined(ENABLE_UNDERGLOW)
         if (g_led_config.flags[i] & LED_FLAG_UNDERGLOW) {
             rgb_matrix_set_color(i, 0, 0, 0);
         }
-            #    endif
+        #endif
     }
     return false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixed variable naming issue preventing compilation.

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
