### PR TITLE
add keyboard suika15tone

### DIFF
--- a/keyboards/suikagiken/suika15tone/keymaps/via/keymap.c
+++ b/keyboards/suikagiken/suika15tone/keymaps/via/keymap.c
@@ -1,0 +1,11 @@
+// Copyright 2024 suikagiken (@suikagiken)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_A,     KC_D, KC_F,      KC_I, KC_K, KC_M,
+        KC_B, KC_C, KC_E, KC_G, KC_H, KC_J, KC_L, KC_N, KC_O
+    )
+};

--- a/keyboards/suikagiken/suika15tone/keymaps/via/rules.mk
+++ b/keyboards/suikagiken/suika15tone/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add keyboard suika15tone.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/24947
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
