### PR TITLE
Add support toggle RGB LED zone for Zed65 Rev1.2

### DIFF
--- a/keyboards/mechlovin/zed65/rev1/logo_led.c
+++ b/keyboards/mechlovin/zed65/rev1/logo_led.c
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Mechlovin'
+Copyright 2025 Mechlovin'
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -15,17 +15,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include QMK_KEYBOARD_H
 #include "logo_led.h"
+#include "rgblight.h"
 
-const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_65_ansi_split_bs(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  KC_HOME,
-        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,          KC_PGUP,
-        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,           KC_PGDN,
-        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_END,
-        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, KC_RGUI, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
-    )
+enum via_rgblight_value {
+    id_rgblight_logo_toggle = 1,
+    id_rgblight_ug_toggle   = 2,
 };
 
 // Process commands from VIA
@@ -47,4 +42,23 @@ void via_custom_value_command_kb(uint8_t *data, uint8_t length) {
         return;
     }
     data[0] = id_unhandled;
+}
+
+// Set values
+void rgblight_config_set_value(uint8_t *data) {
+    switch (data[0]) {
+        case id_rgblight_logo_toggle:
+            g_custom_rgblight_config.logo_enabled = data[1];
+            break;
+        case id_rgblight_ug_toggle:
+            g_custom_rgblight_config.ug_enabled = data[1];
+            break;
+    }
+    rgblight_config_save();
+    update_rgblight();
+}
+
+// Get values
+void rgblight_config_get_value(uint8_t *data) {
+    data[1] = (data[0] == id_rgblight_logo_toggle) ? g_custom_rgblight_config.logo_enabled : g_custom_rgblight_config.ug_enabled;
 }

--- a/keyboards/mechlovin/zed65/rev1/logo_led.h
+++ b/keyboards/mechlovin/zed65/rev1/logo_led.h
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 Mechlovin'
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "quantum.h"
+#include "rgblight.h"
+#include "via.h"
+#include "eeconfig.h"
+#include "rev1.h"
+
+enum via_rgblight_value {
+    id_rgblight_logo_toggle = 1,
+    id_rgblight_ug_toggle   = 2,
+};
+
+void rgblight_config_set_value(uint8_t *data);
+void rgblight_config_get_value(uint8_t *data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As title, support separate toggle rgblight for logo (top-right) and underglow.
## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/23331
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [x] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
