### PR TITLE
Add Coban Pad 12A

### DIFF
--- a/keyboards/coban/pad12a/keymaps/via/keymap.c
+++ b/keyboards/coban/pad12a/keymaps/via/keymap.c
@@ -1,0 +1,19 @@
+// Copyright 2025 RyanDam (https://github.com/RyanDam)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+    KC_MPLY,   KC_MPRV,   KC_MUTE,   KC_MNXT,
+    KC_PGUP,   KC_ESC,    KC_UP,     KC_ENT,
+    KC_PGDN,   KC_LEFT,   KC_DOWN,   KC_RIGHT
+  ),
+};
+
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [0] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU) },
+};
+#endif

--- a/keyboards/coban/pad12a/keymaps/via/rules.mk
+++ b/keyboards/coban/pad12a/keymaps/via/rules.mk
@@ -1,0 +1,3 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes
+ENCODER_MAP_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Add VIA support for Coban Pad 12A

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/25039

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
