### PR TITLE
fixup kb38 keymap

### DIFF
--- a/keyboards/doio/kb38/keymaps/via/keymap.c
+++ b/keyboards/doio/kb38/keymaps/via/keymap.c
@@ -1,3 +1,4 @@
+
 /* Copyright 2021 Katrina (@PepperKats)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -17,40 +18,47 @@
 #include QMK_KEYBOARD_H
 
 enum layers {
-    _QWERTY,
-    _LAYERTWO
+    _BASE,
+    _FN
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* ┌───┐   ┌───────┐┌───┬───┬───┐┌───┬───┬───┐
-     * │ESC│   │KC_BSPC││F1 │F2 │F3 ││F4 │F5 │F6 │
+     * │Fn │   │KC_BSPC││F1 │F2 │F3 ││F4 │F5 │F6 │
      * └───┘   └───────┘└───┴───┴───┘└───┴───┴───┘
      * ┌───┬───┬───┬───┐┌───┬───┬───┐
-     * │NUM│ / │ * │ - ││PAS│SCR│PSC│
+     * │NUM│ / │ * │ - ││PSC│SCR│PAS│
      * ├───┼───┼───┼───┤├───┼───┼───┤┌───┐   ┌───┐
      * │ 7 │ 8 │ 9 │   ││INS│HOM│PGU││HOM│   │END│
      * ├───┼───┼───┤ + │├───┼───┼───┤├───┴───┴───┤
-     * │ 4 │ 5 │ 6 │   ││END│DEL│PGD││           │
+     * │ 4 │ 5 │ 6 │   ││DEL│END│PGD││           │
      * ├───┼───┼───┼───┤└───┼───┼───┘│           │
-     * │ 1 │ 2 │ 3 │ E │    │UP │    │     B     │
+     * │ 1 │ 2 │ 3 │ E │    │UP │    │           │
      * ├───┴───┼───┤ N │┌───┼───┼───┐│           │
      * │   0   │DEL│ T ││LFT│DWN│RHT││           │
      * └───────┴───┴───┘└───┴───┴───┘└───────────┘
      */
-    [_QWERTY] = LAYOUT(
-        MO(1),            KC_BSPC,             RGB_RMOD, RGB_TOG, RGB_MOD,    KC_F1,   KC_F2,   KC_F3,
-        KC_NUM,  KC_PSLS, KC_PAST, KC_PMNS,    KC_PAUS,  KC_SCRL, KC_PSCR,
+    [_BASE] = LAYOUT(
+        MO(_FN),          KC_BSPC,             KC_F1,    KC_F2,   KC_F3,      KC_F4,   KC_F5,   KC_F6,
+        KC_NUM,  KC_PSLS, KC_PAST, KC_PMNS,    KC_PSCR,  KC_SCRL, KC_PAUS,
         KC_P7,   KC_P8,   KC_P9,   KC_PPLS,    KC_INS,   KC_HOME, KC_PGUP,    KC_HOME,          KC_END,
-        KC_P4,   KC_P5,   KC_P6,               KC_END,   KC_DEL,  KC_PGDN,
-        KC_P1,   KC_P2,   KC_P3,   KC_PENT,              KC_UP,                        KC_B,
+        KC_P4,   KC_P5,   KC_P6,               KC_DEL,   KC_END,  KC_PGDN,
+        KC_P1,   KC_P2,   KC_P3,   KC_PENT,              KC_UP,                        KC_NO,
         KC_P0,            KC_PDOT,             KC_LEFT,  KC_DOWN, KC_RGHT
     ),
-    [_LAYERTWO] = LAYOUT(
-        _______,          KC_BSPC,             RGB_RMOD, RGB_TOG, RGB_MOD,    KC_A,    QK_RBT,  QK_BOOT,
-        KC_NUM,  KC_PSLS, KC_PAST, KC_PMNS,    KC_PAUS,  KC_SCRL, KC_PSCR,
-        KC_P7,   KC_P8,   KC_P9,   KC_PPLS,    KC_INS,   KC_HOME, KC_PGUP,    KC_HOME,          KC_END,
-        KC_P4,   KC_P5,   KC_P6,               KC_END,   KC_DEL,  KC_PGDN,
-        KC_P1,   KC_P2,   KC_P3,   KC_PENT,              KC_UP,                        KC_B,
-        KC_P0,            KC_PDOT,             KC_LEFT,  KC_DOWN, KC_RGHT
+    [_FN] = LAYOUT(
+        _______,          RGB_TOG,             _______,  RGB_SAD, RGB_SAI,    RGB_RMOD, RGB_MOD, _______,
+        _______, _______, _______, _______,    _______,  _______, _______,
+        _______, _______, _______, _______,    _______,  _______, _______,    RGB_SPD,           RGB_SPI,
+        _______, _______, _______,             _______,  _______, _______,
+        _______, _______, _______, _______,              _______,                       KC_NO,
+        _______,          _______,             _______,  _______, _______
     )
 };
+
+#ifdef ENCODER_MAP_ENABLE
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [_BASE] = { ENCODER_CCW_CW(KC_PGUP, KC_PGDN), ENCODER_CCW_CW(MS_WHLU, MS_WHLD), ENCODER_CCW_CW(KC_VOLD, KC_VOLU) },
+    [_FN]   = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) }
+};
+#endif


### PR DESCRIPTION
## Description

add `encoder_map` to allow firmware to compile
general cleanup of keymap

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/19650

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
