### PR TITLE
enable LTO for kb38

### DIFF
--- a/keyboards/doio/kb38/keymaps/via/rules.mk
+++ b/keyboards/doio/kb38/keymaps/via/rules.mk
@@ -1,2 +1,3 @@
 VIA_ENABLE = yes
 ENCODER_MAP_ENABLE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
## Description

fixes missed item in #84 
(enable LTO to allow firmware to fit on MCU)

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/19650

## Checklist

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
