### PR TITLE
initial commit lilbae keyboard layout

### DIFF
--- a/keyboards/sneakbox/lilbae/keymaps/via/keymap.c
+++ b/keyboards/sneakbox/lilbae/keymaps/via/keymap.c
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 Bryan Ong
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    _BASE,
+    _FN,
+    _L3,
+    _L4
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+      [_BASE] = LAYOUT(
+              KC_NO,
+    KC_ESC, KC_ENT, KC_LGUI),
+
+    [_FN] = LAYOUT(
+              KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS),
+    [_L3] = LAYOUT(
+              KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS),
+    [_L4] = LAYOUT(
+              KC_TRNS,
+    KC_TRNS, KC_TRNS, KC_TRNS),
+};
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [_BASE] = { ENCODER_CCW_CW(KC_1, KC_2)},
+    [_FN]   = { ENCODER_CCW_CW(KC_1, KC_2)},
+    [_L3]   = { ENCODER_CCW_CW(KC_1, KC_2)},
+    [_L4]   = { ENCODER_CCW_CW(KC_1, KC_2)}
+};
+#endif

--- a/keyboards/sneakbox/lilbae/keymaps/via/rules.mk
+++ b/keyboards/sneakbox/lilbae/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+ENCODER_MAP_ENABLE = yes


### PR DESCRIPTION
## Description
Initial commit for VIA key layout for LilBAE macropad

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/25259
<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
