### PR TITLE
Add null65ansi VIA keymap

### DIFF
--- a/keyboards/nulldesignco/null65ansi/v1/keymaps/via/keymap.c
+++ b/keyboards/nulldesignco/null65ansi/v1/keymaps/via/keymap.c
@@ -1,0 +1,22 @@
+// Copyright 2025 quark-works
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT_65_ansi(
+        QK_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_HOME,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_PGDN,
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                             KC_RALT, KC_APP,  KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    )
+};
+
+bool rgb_matrix_indicators_user(void) {
+    if (host_keyboard_led_state().caps_lock) {
+    	rgb_matrix_set_color(24, 255, 0, 0);
+    }
+    return false;
+}

--- a/keyboards/nulldesignco/null65ansi/v1/keymaps/via/rules.mk
+++ b/keyboards/nulldesignco/null65ansi/v1/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added null65ansi keyboard

<!--- Describe your changes in detail here. -->

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/25464
Already merged to main: https://github.com/qmk/qmk_firmware/tree/master/keyboards/nulldesignco/null65ansi

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [x] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`

I'm not sure if rgb matrix menus count as custom menus. Marking it just in case.