### PR TITLE
fix lilbae layout name

### DIFF
--- a/keyboards/sneakbox/lilbae/keymaps/via/keymap.c
+++ b/keyboards/sneakbox/lilbae/keymaps/via/keymap.c
@@ -27,17 +27,19 @@ enum layer_names {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-      [_BASE] = LAYOUT(
+    [_BASE] = LAYOUT_all(
               KC_NO,
     KC_ESC, KC_ENT, KC_LGUI),
 
-    [_FN] = LAYOUT(
+    [_FN]   = LAYOUT_all(
               KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS),
-    [_L3] = LAYOUT(
+
+    [_L3]   = LAYOUT_all(
               KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS),
-    [_L4] = LAYOUT(
+
+    [_L4]   = LAYOUT_all(
               KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS),
 };


### PR DESCRIPTION
multiple layout [QMK json](https://github.com/qmk/qmk_firmware/blob/master/keyboards/sneakbox/lilbae/keyboard.json#L36-L43), this keymap should use `LAYOUT_all` rather than `LAYOUT`

## Description

fix layout name, minor format nits

## QMK Pull Request

fixes the-via/qmk_userspace_via #98 

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
