### PR TITLE
Switched SPIN macropad to encoder map

### DIFF
--- a/keyboards/dmqdesign/spin/keymaps/via/config.h
+++ b/keyboards/dmqdesign/spin/keymaps/via/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2025 Adam Kraus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#define RGBLIGHT_HUE_STEP 8
+
+#define ENCODER_A_PINS { B6, B4, D6 }
+#define ENCODER_B_PINS { B5, D7, D4 }

--- a/keyboards/dmqdesign/spin/keymaps/via/keymap.c
+++ b/keyboards/dmqdesign/spin/keymaps/via/keymap.c
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 adamkraus6
+/* Copyright 2020-2025 Adam Kraus
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,6 +14,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include QMK_KEYBOARD_H
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [0] = { ENCODER_CCW_CW(UG_HUED, UG_HUEU),  ENCODER_CCW_CW(UG_SATD, UG_SATU),  ENCODER_CCW_CW(UG_VALD, UG_VALU)  },
+    [1] = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS),  ENCODER_CCW_CW(KC_TRNS, KC_TRNS),  ENCODER_CCW_CW(KC_TRNS, KC_TRNS)  },
+    [2] = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS),  ENCODER_CCW_CW(KC_TRNS, KC_TRNS),  ENCODER_CCW_CW(KC_TRNS, KC_TRNS)  },
+    [3] = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS),  ENCODER_CCW_CW(KC_TRNS, KC_TRNS),  ENCODER_CCW_CW(KC_TRNS, KC_TRNS)  },
+};
+#endif
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
@@ -44,26 +53,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_NO,     KC_NO,     KC_NO
         )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) { /* First encoder */
-        if (clockwise) {
-        rgblight_increase_hue(); //Cycle through the RGB hue
-        } else {
-        rgblight_decrease_hue();
-        }
-    } else if (index == 1) { /* Second encoder */
-        if (clockwise) {
-        rgblight_increase_sat();
-        } else {
-        rgblight_decrease_sat();
-        }
-    } else if (index == 2) { /* Third encoder */
-        if (clockwise) {
-        rgblight_increase_val(); //Change brightness on the RGB LEDs
-        } else {
-        rgblight_decrease_val();
-        }
-    }
-    return true;
-}

--- a/keyboards/dmqdesign/spin/keymaps/via/rules.mk
+++ b/keyboards/dmqdesign/spin/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+ENCODER_MAP_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added encoder support instead of being hard coded.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

https://github.com/qmk/qmk_firmware/pull/12300

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [x] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
