### PR TITLE
Add nullpad

### DIFF
--- a/keyboards/nulldesignco/nullpad/v1/keymaps/via/config.h
+++ b/keyboards/nulldesignco/nullpad/v1/keymaps/via/config.h
@@ -1,0 +1,2 @@
+#define COMBO_TERM 300
+#define COMBO_MUST_PRESS_IN_ORDER

--- a/keyboards/nulldesignco/nullpad/v1/keymaps/via/keymap.c
+++ b/keyboards/nulldesignco/nullpad/v1/keymaps/via/keymap.c
@@ -1,0 +1,43 @@
+// Copyright 2025 quark-works
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+enum combos {
+    UNLOCK_COMBO
+};
+
+const uint16_t PROGMEM unlock_combo[] = {KC_NUM, KC_P0, KC_PENT, COMBO_END};
+
+combo_t key_combos[] = {
+    [UNLOCK_COMBO] = COMBO(unlock_combo, SE_UNLK),
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT_numpad_5x4(
+        KC_NUM,  KC_PSLS, KC_PAST, KC_PMNS,
+        KC_P7,   KC_P8,   KC_P9,
+        KC_P4,   KC_P5,   KC_P6,   KC_PPLS,
+        KC_P1,   KC_P2,   KC_P3,
+        KC_P0,            KC_PDOT, KC_PENT
+    )
+};
+
+bool rgb_matrix_indicators_user(void) {
+    if (host_keyboard_led_state().num_lock) {
+        rgb_matrix_set_color(16, 255, 0, 0);
+    }
+    return false;
+}
+
+#ifdef COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
+bool get_combo_must_press_in_order(uint16_t combo_index, combo_t *combo) {
+    switch (combo_index) {
+        case UNLOCK_COMBO:
+            return true;
+        default:
+            return false;
+    }
+}
+#endif

--- a/keyboards/nulldesignco/nullpad/v1/keymaps/via/rules.mk
+++ b/keyboards/nulldesignco/nullpad/v1/keymaps/via/rules.mk
@@ -1,0 +1,4 @@
+VIA_ENABLE = yes
+SECURE_ENABLE = yes
+COMBO_ENABLE = yes
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adding support for the nullpad board
<!--- Describe your changes in detail here. -->

## QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/26057

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [x] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
