### PR TITLE
Added keyboard pad9.

### DIFF
--- a/keyboards/pad9/keymaps/via/keymap.c
+++ b/keyboards/pad9/keymaps/via/keymap.c
@@ -1,0 +1,45 @@
+// Copyright 2023 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [0] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU)  },
+    [1] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU)  },
+    [2] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU)  },
+    [3] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU)  }
+};
+#endif
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┐
+     * │ A │ B │ C │
+     * ├───┼───┼───┤
+     * │ D │ E │ F │
+     * ├───┼───┼───┤
+     * │ G │ H │ I │
+     * └───┴───┴───┘
+     */
+    [0] = LAYOUT_ortho_3x3(
+        KC_1,    KC_2,    KC_3,
+        KC_4,    KC_5,    KC_6,
+        KC_7,    KC_8,    KC_9
+    ),
+    [1] = LAYOUT_ortho_3x3(
+        KC_1,    KC_2,    KC_3,
+        KC_4,    KC_5,    KC_6,
+        KC_7,    KC_8,    KC_9
+    ),
+    [2] = LAYOUT_ortho_3x3(
+        KC_1,    KC_2,    KC_3,
+        KC_4,    KC_5,    KC_6,
+        KC_7,    KC_8,    KC_9
+    ),
+    [3] = LAYOUT_ortho_3x3(
+        KC_1,    KC_2,    KC_3,
+        KC_4,    KC_5,    KC_6,
+        KC_7,    KC_8,    KC_9
+    )
+};

--- a/keyboards/pad9/keymaps/via/rules.mk
+++ b/keyboards/pad9/keymaps/via/rules.mk
@@ -1,0 +1,4 @@
+ENCODER_ENABLE = yes
+ENCODER_MAP_ENABLE = yes
+
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Added [keyboard pad9](https://github.com/qmk/qmk_firmware/tree/master/keyboards/pad9) from QMK.

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/26051

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
