### PR TITLE
add Curve0 75% ANSI

### DIFF
--- a/keyboards/kbd0/curve0/75_ansi/keymaps/via/keymap.json
+++ b/keyboards/kbd0/curve0/75_ansi/keymaps/via/keymap.json
@@ -1,0 +1,16 @@
+{
+    "author": "kbd0",
+    "keyboard": "kbd0/curve0/75_ansi",
+    "keymap": "via",
+    "layout": "LAYOUT_all",
+    "layers": [
+        [
+          "KC_ESC",  "KC_F1",    "KC_F2",    "KC_F3",    "KC_F4",    "KC_F5",    "KC_F6",    "KC_F7",    "KC_F8",    "KC_F9",    "KC_F10",    "KC_F11", "KC_F12",  "KC_PRINT_SCREEN", "KC_DELETE", "KC_INSERT",
+          "KC_GRAVE",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_BSPC", "KC_HOME",
+          "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_END",
+          "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT", "KC_PGUP",
+          "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP", "KC_PGDN",
+          "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                    "KC_RALT", "KC_APP", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RIGHT"
+        ]
+    ]
+}

--- a/keyboards/kbd0/curve0/75_ansi/keymaps/via/rules.mk
+++ b/keyboards/kbd0/curve0/75_ansi/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

add Curve0 75% ANSI

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->
https://github.com/qmk/qmk_firmware/pull/25997

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
