### PR TITLE
Add HMC Studio +84 Classic TKL VIA keymap

### DIFF
--- a/keyboards/hmc/nuxroskb/plus_84_classic_tkl/keymaps/via/config.h
+++ b/keyboards/hmc/nuxroskb/plus_84_classic_tkl/keymaps/via/config.h
@@ -1,0 +1,6 @@
+// Copyright 2026 HMC Studio
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 4

--- a/keyboards/hmc/nuxroskb/plus_84_classic_tkl/keymaps/via/keymap.c
+++ b/keyboards/hmc/nuxroskb/plus_84_classic_tkl/keymaps/via/keymap.c
@@ -1,0 +1,45 @@
+// Copyright 2026 HMC Studio
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// VIA userspace overlay for hmc/nuxroskb/plus_84_classic_tkl.
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT_all(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,                    KC_PSCR, KC_SCRL, KC_PAUS,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_TRNS, KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_DEL,  KC_END,  KC_PGDN,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,
+        KC_LSFT, KC_TRNS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_TRNS,                     KC_UP,
+        KC_LCTL, KC_LGUI, KC_LALT,                   KC_SPC,                                               KC_RALT, MO(1),   KC_RCTL,          KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [1] = LAYOUT_all(
+        QK_BOOT, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RM_VALU,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, RM_VALD,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, RM_HUED, RM_HUEU, RM_SATD, RM_SATU, RM_PREV, RM_NEXT, RM_SPDD, RM_SPDU, KC_TRNS, RM_TOGG, KC_TRNS, KC_TRNS,                   KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+
+    [2] = LAYOUT_all(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RM_VALU,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, RM_VALD,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, RM_HUED, RM_HUEU, RM_SATD, RM_SATU, RM_PREV, RM_NEXT, RM_SPDD, RM_SPDU, KC_TRNS, RM_TOGG, KC_TRNS, KC_TRNS,                   KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+
+    [3] = LAYOUT_all(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, RM_VALU,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, RM_VALD,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, RM_HUED, RM_HUEU, RM_SATD, RM_SATU, RM_PREV, RM_NEXT, RM_SPDD, RM_SPDU, KC_TRNS, RM_TOGG, KC_TRNS, KC_TRNS,                   KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                                     KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS
+    )
+};

--- a/keyboards/hmc/nuxroskb/plus_84_classic_tkl/keymaps/via/rules.mk
+++ b/keyboards/hmc/nuxroskb/plus_84_classic_tkl/keymaps/via/rules.mk
@@ -1,0 +1,6 @@
+# Copyright 2026 HMC Studio
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+VIA_ENABLE = yes
+VIA_INSECURE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
 Description

Adds the VIA keymap for `hmc/nuxroskb/plus_84_classic_tkl`.



 QMK Pull Request

https://github.com/qmk/qmk_firmware/pull/26392

 Checklist

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device. **(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
